### PR TITLE
Improve contact email flow and iOS viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <title>Wanderlust - Travel Blog</title>
     <meta name="description" content="Join me on my journey around the world, discovering budget-friendly travel tips and adventures." />
     <meta name="author" content="[Your Name]" />

--- a/src/components/monetization/QuickPlannerDialog.tsx
+++ b/src/components/monetization/QuickPlannerDialog.tsx
@@ -12,6 +12,7 @@ interface PlannerFormData {
   duration: string;
   preferences: string;
   budget: string;
+  email: string;
 }
 
 export const QuickPlannerDialog = () => {
@@ -21,7 +22,8 @@ export const QuickPlannerDialog = () => {
     destination: "",
     duration: "",
     preferences: "",
-    budget: ""
+    budget: "",
+    email: ""
   });
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -33,7 +35,7 @@ export const QuickPlannerDialog = () => {
         body: {
           firstName: "Travel Inquiry",
           lastName: "",
-          email: "traveler@example.com",
+          email: formData.email,
           phone: "",
           message: `New Travel Inquiry:
 Destination: ${formData.destination}
@@ -54,7 +56,8 @@ Travel Preferences: ${formData.preferences}`
         destination: "",
         duration: "",
         preferences: "",
-        budget: ""
+        budget: "",
+        email: ""
       });
     } catch (error) {
       console.error("Error sending inquiry:", error);
@@ -130,6 +133,21 @@ Travel Preferences: ${formData.preferences}`
               required
               disabled={isLoading}
               placeholder="e.g., $2000-3000"
+            />
+          </div>
+          <div className="space-y-2">
+            <label htmlFor="email" className="text-sm font-medium">
+              Your Email
+            </label>
+            <Input
+              id="email"
+              name="email"
+              type="email"
+              value={formData.email}
+              onChange={handleChange}
+              required
+              disabled={isLoading}
+              placeholder="you@example.com"
             />
           </div>
           <div className="space-y-2">

--- a/supabase/functions/send-contact-email/index.ts
+++ b/supabase/functions/send-contact-email/index.ts
@@ -15,12 +15,16 @@ const handler = async (req: Request): Promise<Response> => {
   }
 
   try {
-    const resend = new Resend("re_4iLKvT3s_5vxAHCzA4QnibpgSRLCm3KTC");
+    const apiKey = Deno.env.get("RESEND_API_KEY");
+    if (!apiKey) {
+      throw new Error("RESEND_API_KEY is not set");
+    }
+    const resend = new Resend(apiKey);
     const { firstName, lastName, email, phone, message } = await req.json();
 
     const emailResponse = await resend.emails.send({
       from: "onboarding@resend.dev",
-      to: "Shobhitchoudhury1@gmail.com",
+      to: "shobhitchoudhury1@gmail.com",
       subject: "New Contact Form Submission",
       html: `
         <h2>New Contact Form Submission</h2>


### PR DESCRIPTION
## Summary
- allow users to enter their email when requesting a travel plan
- send travel inquiries to the provided email address
- reset email field after submitting
- use environment variable for Resend API key and update destination email
- add `viewport-fit=cover` so the blog works on iOS safe areas

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find ESLint package)*

------
https://chatgpt.com/codex/tasks/task_e_6852d53ba080832aa703657ef8dcfb28