### PR TITLE
Fix background turning navy blue by locking theme to light mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ const queryClient = new QueryClient();
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
       <TooltipProvider>
         <Toaster />
         <Sonner />


### PR DESCRIPTION
Disabled system theme detection (defaultTheme="system" with enableSystem) which caused the site to inherit dark mode from the OS, resulting in a navy blue background. Now always uses light theme.